### PR TITLE
Removed binary refrences from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "scripts": {
     "start": "node ./app.js",
-    "test": "./node_modules/.bin/mocha --reporter spec",
-    "lint": "./node_modules/.bin/eslint ."
+    "test": "mocha --reporter spec",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's not necessary to reference binaries. Npm puts them all in `PATH` before running scripts: https://docs.npmjs.com/misc/scripts#path
