### PR TITLE
Admin commands rework

### DIFF
--- a/helpers/logic.js
+++ b/helpers/logic.js
@@ -47,13 +47,13 @@ bot.on('message', (msg) => {
         handleKeyboard(msg);
       } else if (check.botCommandStart(msg)) {
         keyboards.sendMainMenu(bot, msg.chat.id, false);
+      } else if (check.adminCommand(msg)) {
+        adminPanel.handleAdminCommand(msg, bot);
       } else {
         /** todo: handle strange message */
       }
     } else if (check.botCommandStart(msg)) {
       profile.createProfile(bot, msg);
-    } else if (check.adminCommand(msg)) {
-      adminPanel.handleAdminCommand(msg, bot);
     }
   });
 });

--- a/helpers/messageParser.js
+++ b/helpers/messageParser.js
@@ -26,19 +26,15 @@ function botCommandStart(message) {
 
 /**
  * Checks if message is an admin command
+ * Every admin message starts with: /admin
+ * /admin_ban
+ * /admin_unban
+ * /admin_godvoice
  * @param {Telegram:Message} message - Message to check
  * @return {Boolean} True if admin command, false otherwise
  */
 function adminCommand(message) {
-  const adminCommands = ['/ban', '/unban', '/godvoice'];
-
-  for (let i = 0; i < adminCommands.length; i += 1) {
-    if (message.text.indexOf(adminCommands[i]) > -1) {
-      return true;
-    }
-  }
-
-  return false;
+  return message.text.indexOf('/admin') == 0;
 }
 
 /**


### PR DESCRIPTION
Fixed a bug with if-else statements in logic.js: user could not use any /admin commands - all of them were detected as "strange"
Made a remake of admins commands:
1. Now any admin command should start with '/admin'.
2. Simplified the way how bot detected the message to be sent to all users from /godvoice command.
